### PR TITLE
[JENKINS-44445] Switch to Java 7 NIO directory walker to compute disk usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580.3</version>
+    <version>2.22</version>
   </parent>
 
   <artifactId>cloudbees-disk-usage-simple</artifactId>
@@ -156,32 +156,4 @@
       </plugins>
     </pluginManagement>
   </build>
-
-  <profiles>
-    <profile>
-      <id>dev-on-macos</id>
-      <activation>
-        <os>
-          <family>mac</family>
-        </os>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.jenkins-ci.tools</groupId>
-              <artifactId>maven-hpi-plugin</artifactId>
-              <configuration>
-                <systemProperties>
-                  <!-- There is no ionice command on MacOS X -->
-                  <com.cloudbees.simplediskusage.QuickDiskUsagePlugin.command>du -ks</com.cloudbees.simplediskusage.QuickDiskUsagePlugin.command>
-                </systemProperties>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
-
 </project>

--- a/src/main/java/com/cloudbees/simplediskusage/UsageComputation.java
+++ b/src/main/java/com/cloudbees/simplediskusage/UsageComputation.java
@@ -1,0 +1,104 @@
+package com.cloudbees.simplediskusage;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Compute disk usage of a list of paths. Results are published using
+ * listeners registered for interesting paths, so we only walk the disk once.
+ *
+ * The walker process is throttled to prevent IO starvation for other Jenkins
+ * tasks.
+ */
+public class UsageComputation {
+
+    public interface CompletionListener {
+        void onCompleted(Path dir, long usage);
+    }
+
+    Map<Path, CompletionListener> listenerMap;
+
+    final List<Path> pathsToScan;
+
+    public UsageComputation(List<Path> pathsToScan) {
+        this.pathsToScan = pathsToScan;
+        this.listenerMap = new HashMap<>();
+    }
+
+    public void addListener(Path path, CompletionListener listener) {
+        listenerMap.put(path.toAbsolutePath(), listener);
+    }
+
+    public void compute() throws IOException {
+        for (Path path : pathsToScan) {
+            computeUsage(path.toAbsolutePath());
+        }
+    }
+
+    protected void computeUsage(Path path) throws IOException {
+        // we don't really need AtomicLong here, walking the tree is synchronous, but
+        // it's convenient for the operations it provides
+        final AtomicLong chunkStartTime = new AtomicLong(System.currentTimeMillis());
+        final Stack<AtomicLong> computeStack = new Stack<>();
+        computeStack.push(new AtomicLong(0));
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                computeStack.push(new AtomicLong(0));
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                computeStack.peek().addAndGet(attrs.size());
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+                if (exc != null) {
+                    logger.log(Level.INFO, "Exception thrown while walking {}: {}", new Object[] {dir, exc });
+                }
+
+                // throttle the walking process so it only consumes at most half of the available IO bandwidth
+                // only pause every 100ms to ensure the walk is efficient anyway
+                long runTimeInMillis = System.currentTimeMillis() - chunkStartTime.get();
+                if (runTimeInMillis > 100) {
+                    try {
+                        Thread.sleep(runTimeInMillis);
+                        chunkStartTime.set(System.currentTimeMillis());
+                    } catch (InterruptedException e) {
+                        return FileVisitResult.TERMINATE;
+                    }
+                }
+
+                long pathDiskUsage = computeStack.pop().get();
+                CompletionListener listener = listenerMap.get(dir);
+                if (listener != null) {
+                    listener.onCompleted(dir, pathDiskUsage);
+                }
+
+                computeStack.peek().addAndGet(pathDiskUsage);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static final Logger logger = Logger.getLogger(UsageComputation.class.getName());
+}

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -23,6 +23,7 @@
     THE SOFTWARE.
 
 -->
+<?jelly escape-by-default='true'?>
 <div>
     Alternative to disk-usage plugin, to compute in the background per job disk usage on jenkins master
 </div>

--- a/src/test/java/com/cloudbees/simplediskusage/UsageComputationTest.java
+++ b/src/test/java/com/cloudbees/simplediskusage/UsageComputationTest.java
@@ -1,0 +1,31 @@
+package com.cloudbees.simplediskusage;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class UsageComputationTest {
+    @Test
+    public void compute() throws Exception {
+        final AtomicBoolean notified = new AtomicBoolean(false);
+        final AtomicLong testUsage = new AtomicLong(0);
+
+        final UsageComputation uc = new UsageComputation(Arrays.asList(Paths.get(".")));
+        uc.addListener(Paths.get("."), new UsageComputation.CompletionListener() {
+            @Override
+            public void onCompleted(Path dir, long usage) {
+                notified.set(true);
+                testUsage.set(usage);
+            }
+        });
+        uc.compute();
+
+        Assert.assertTrue(notified.get());
+        Assert.assertTrue(testUsage.get() >  0);
+    }
+}


### PR DESCRIPTION
The plugin currently uses `du -k`  to compute disk usage. This is not portable and not efficient:  the plugin walks the Jenkins root folder at least twice, once for jobs, once for the whole folder.

Moreover, the IO throttling mechanism uses `ionice` which is not effective on all platforms and depends whether there's a IO scheduler available on Linux which is not the case anymore when mq-blk is active. Let's switch to something simpler and working everywhere.

[JENKINS-44445](https://issues.jenkins-ci.org/browse/JENKINS-44445)

@reviewbybees esp @aheritier