### PR TITLE
[JENKINS-45943] Postpone disk usage update after Jenkins is fully up

### DIFF
--- a/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsageInitializer.java
+++ b/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsageInitializer.java
@@ -29,7 +29,11 @@ import jenkins.model.Jenkins;
 
 public class QuickDiskUsageInitializer {
     /**
-     * Let's update data after Jenkins is started and all jobs are loaded
+     * Let's trigger an update after Jenkins is fully up.
+     *
+     * JOB_LOADED is the last milestone that can be triggered with an @Initializer,
+     * COMPLETED doesn't work. So, we queue the update and check that Jenkins is fully up in the runnable
+     * used in refreshDataOnStartup()
      */
     @Initializer(after = InitMilestone.JOB_LOADED)
     public static void initialize() {
@@ -40,7 +44,7 @@ public class QuickDiskUsageInitializer {
         }
         QuickDiskUsagePlugin plugin = jenkins.getPlugin(QuickDiskUsagePlugin.class);
         if (plugin == null) return;
-        plugin.refreshData();
+        plugin.refreshDataOnStartup();
     }
 
 }


### PR DESCRIPTION
Currently, the plugin starts to update the usage data after jobs are loaded but before Jenkins is fully up. This slows down operations done by other components after `InitMilestone.JOB_LOADED` is reached.

Disk usage should only be computed after Jenkins is fully up.

[JENKINS-45943](https://issues.jenkins-ci.org/browse/JENKINS-45943)

@reviewbybees