### PR TITLE
show a progress bar to inform end-user about the current status

### DIFF
--- a/src/main/java/com/cloudbees/simplediskusage/UsageComputation.java
+++ b/src/main/java/com/cloudbees/simplediskusage/UsageComputation.java
@@ -43,6 +43,10 @@ public class UsageComputation {
         listenerMap.put(path.toAbsolutePath(), listener);
     }
 
+    public int getItemsCount() {
+        return listenerMap.size();
+    }
+
     public void compute() throws IOException {
         for (Path path : pathsToScan) {
             computeUsage(path.toAbsolutePath());

--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/message.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/message.jelly
@@ -34,6 +34,9 @@
             <j:when test="${it.running}">
                 <strong>Update in progress</strong>, please
                 <a href=".">try again in a short while</a>
+                <br/>
+                <progress value="${it.progress}" max="${it.itemsCount}"/>
+                <br/>
             </j:when>
             <j:otherwise>
                 Computed ${it.since} ago. Took ${it.duration}.


### PR DESCRIPTION
As computation can take long time, end user might stay waiting for computation without feedback on actual progress, getting nervous and start hitting the "refresh" button dozen times. 

This PR introduce a progress bar (html5 browser required) to give him some visual feedback

<img width="395" alt="capture d ecran 2017-09-29 a 09 16 53" src="https://user-images.githubusercontent.com/132757/31005125-a96e9b9e-a4f7-11e7-84fa-0241b482aabf.png">
