### PR TITLE
Transient atomics to prevent serialization issues

### DIFF
--- a/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
+++ b/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
@@ -71,9 +71,9 @@ public class QuickDiskUsagePlugin extends Plugin {
 
     private long lastRunEnd = 0;
 
-    private final AtomicInteger progress = new AtomicInteger();
+    private transient final AtomicInteger progress = new AtomicInteger();
     
-    private final AtomicInteger total = new AtomicInteger();
+    private transient final AtomicInteger total = new AtomicInteger();
 
     @Override
     public void start() throws Exception {


### PR DESCRIPTION
Make the atomics transient to prevent JEP-200 warnings
```
WARNING: Failed to save D:\github\cloudbees-disk-usage-simple-plugin\work\cloudbees-disk-usage-simple.xml
java.io.IOException: java.lang.RuntimeException: Failed to serialize com.cloudbees.simplediskusage.QuickDiskUsagePlugin#progress for class com.cloudbees.simplediskusage.QuickDiskUsagePlugin
        at hudson.XmlFile.write(XmlFile.java:200)
        at hudson.Plugin.save(Plugin.java:278)
        at com.cloudbees.simplediskusage.QuickDiskUsagePlugin$2.run(QuickDiskUsagePlugin.java:267)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.RuntimeException: Failed to serialize com.cloudbees.simplediskusage.QuickDiskUsagePlugin#progress for class com.cloudbees.simplediskusage.QuickDiskUsagePlugin
        at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:256)
        at hudson.util.RobustReflectionConverter$2.visit(RobustReflectionConverter.java:224)
        at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.visitSerializableFields(PureJavaReflectionProvider.java:138)
        at hudson.util.RobustReflectionConverter.doMarshal(RobustReflectionConverter.java:209)
        at hudson.util.RobustReflectionConverter.marshal(RobustReflectionConverter.java:150)
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:69)
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:43)
        at com.thoughtworks.xstream.core.TreeMarshaller.start(TreeMarshaller.java:82)
        at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.marshal(AbstractTreeMarshallingStrategy.java:37)
        at com.thoughtworks.xstream.XStream.marshal(XStream.java:1026)
        at com.thoughtworks.xstream.XStream.marshal(XStream.java:1015)
        at com.thoughtworks.xstream.XStream.toXML(XStream.java:988)
        at hudson.XmlFile.write(XmlFile.java:193)
        ... 5 more
Caused by: java.lang.UnsupportedOperationException: Refusing to marshal java.util.concurrent.atomic.AtomicInteger for security reasons; see https://jenkins.io/redirect/class-filter/
        at hudson.util.XStream2$BlacklistedTypesConverter.marshal(XStream2.java:546)
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller.convert(AbstractReferenceMarshaller.java:69)
        at com.thoughtworks.xstream.core.TreeMarshaller.convertAnother(TreeMarshaller.java:58)
        at com.thoughtworks.xstream.core.AbstractReferenceMarshaller$1.convertAnother(AbstractReferenceMarshaller.java:84)
        at hudson.util.RobustReflectionConverter.marshallField(RobustReflectionConverter.java:265)
        at hudson.util.RobustReflectionConverter$2.writeField(RobustReflectionConverter.java:252)
        ... 18 more
```