### PR TITLE
Better logging levels: use FINE rather than INFO

### DIFF
--- a/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
+++ b/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
@@ -246,7 +246,7 @@ public class QuickDiskUsagePlugin extends Plugin {
     private transient final Runnable computeDiskUsage = new Runnable() {
 
         public void run() {
-            logger.info("Re-estimating disk usage");
+            logger.fine("Re-estimating disk usage");
             progress.set(0);
             lastRunStart = System.currentTimeMillis();
             Jenkins jenkins = Jenkins.get();
@@ -256,7 +256,7 @@ public class QuickDiskUsagePlugin extends Plugin {
                 registerDirectories(uc);
                 total.set(uc.getItemsCount());
                 uc.compute();
-                logger.info("Finished re-estimating disk usage.");
+                logger.fine("Finished re-estimating disk usage.");
                 lastRunEnd = System.currentTimeMillis();
             } catch (IOException | InterruptedException e) {
                 logger.log(Level.INFO, "Unable to run disk usage check", e);
@@ -276,7 +276,7 @@ public class QuickDiskUsagePlugin extends Plugin {
             Jenkins jenkins = Jenkins.get();
             while (jenkins.getInitLevel() != InitMilestone.COMPLETED) {
                 try {
-                    logger.log(Level.INFO, "Waiting for Jenkins to be up before computing disk usage");
+                    logger.log(Level.FINE, "Waiting for Jenkins to be up before computing disk usage");
                     Thread.sleep(3 * 60 * 1000);
                 } catch (InterruptedException e) {
                     return;


### PR DESCRIPTION
Better logging levels: use FINE rather than INFO

Jenkins logs are full of debugging messages that should be hidden unless troubleshooting log levels are enabled.
Use "FINE" rather than "INFO" for troubleshooting details.

```
2021-12-08 10:54:11.817+0000 [id=63]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Re-estimating disk usage
2021-12-08 10:54:12.775+0000 [id=63]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Finished re-estimating disk usage.
2021-12-08 11:10:10.036+0000 [id=63]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Re-estimating disk usage
2021-12-08 11:10:11.196+0000 [id=63]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Finished re-estimating disk usage.
2021-12-08 11:26:10.025+0000 [id=63]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Re-estimating disk usage
2021-12-08 11:26:11.175+0000 [id=63]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Finished re-estimating disk usage.
2021-12-08 11:42:10.014+0000 [id=63]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Re-estimating disk usage
2021-12-08 11:42:11.001+0000 [id=63]	INFO	c.c.s.QuickDiskUsagePlugin$2#run: Finished re-estimating disk usage.
````

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
