### PR TITLE
Fix some log levels to WARNING

### DIFF
--- a/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
+++ b/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
@@ -259,7 +259,7 @@ public class QuickDiskUsagePlugin extends Plugin {
                 logger.info("Finished re-estimating disk usage.");
                 lastRunEnd = System.currentTimeMillis();
             } catch (IOException | InterruptedException e) {
-                logger.log(Level.INFO, "Unable to run disk usage check", e);
+                logger.log(Level.WARNING, "Unable to run disk usage check", e);
                 lastRunEnd = lastRunStart;
             }
             try {

--- a/src/main/java/com/cloudbees/simplediskusage/UsageComputation.java
+++ b/src/main/java/com/cloudbees/simplediskusage/UsageComputation.java
@@ -78,7 +78,7 @@ public class UsageComputation {
                     try {
                         jenkinsHome.touch(System.currentTimeMillis());
                     } catch (InterruptedException e) {
-                        logger.log(Level.INFO, "Exception while touching JENKINS_HOME", e);
+                        logger.log(Level.WARNING, "Exception while touching JENKINS_HOME", e);
                     }
                 }
 
@@ -99,7 +99,7 @@ public class UsageComputation {
             @Override
             public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
                 if (exc != null) {
-                    logger.log(Level.INFO, "Exception thrown while walking {}: {}", new Object[] {dir, exc });
+                    logger.log(Level.WARNING, "Exception thrown while walking {}: {}", new Object[] {dir, exc });
                 }
 
                 // throttle the walking process so it only consumes at most half of the available IO bandwidth


### PR DESCRIPTION
We use the plugin over a NFS jenkins home (yes that's bad). We noticed that sometimes the timestamp cannot be set on the JENKINS_HOME folder. We would like to have those logs in WARNING instead of INFO.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

