### PR TITLE
[JENKINS-69321] Tidy sidebar on disk usage page

### DIFF
--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/sidepanel.jelly
@@ -30,6 +30,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:header />
   <l:side-panel>
+    <l:tasks>
       <l:task href="${rootURL}/" icon="icon-up icon-md" title="${%Back to Dashboard}"/>
       <l:task href="${rootURL}/manage" icon="icon-setting icon-md" title="${%Manage Jenkins}"/>
       <l:task href="." icon="/plugin/cloudbees-disk-usage-simple/images/disk.png" title="${%Disk usage}"/>
@@ -43,5 +44,6 @@
               }
           </script>
       </j:if>
+    </l:tasks>
   </l:side-panel>
 </j:jelly>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The problem As [JENKINS-69321](https://issues.jenkins.io/browse/JENKINS-69321) said, the sidebar of the disk usage page is missing the <l:tasks> structure, resulting in all the <l:task> not having the css format it should have.
(similar structure can be found in these files in Jenkins ↓)
![similar_file](https://user-images.githubusercontent.com/95022717/185257379-818be3dc-c7e7-467d-9354-b6c3340004dc.PNG)


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
