### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/sidepanel.jelly
@@ -38,7 +38,10 @@
         <l:task href="." onclick="return refresh(this)" icon="icon-refresh icon-md" title="${%Refresh disk usage}" post="true"/>
           <script>
               function refresh(a) {
-                  new Ajax.Request("refresh");
+                  fetch("refresh", {
+                      method: "post",
+                      headers: crumb.wrap({}),
+                  });
                   hoverNotification('${%Refresh scheduled}',a.parentNode);
                   return true;
               }


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), clicked on the Refresh link, and verified in my browser's debugger that the POST request was submitted successfully as before and that the "Refresh scheduled" tooltip was displayed.