### PR TITLE
feat: add file count metric

### DIFF
--- a/src/main/java/com/cloudbees/simplediskusage/DiskItem.java
+++ b/src/main/java/com/cloudbees/simplediskusage/DiskItem.java
@@ -36,11 +36,18 @@ public class DiskItem implements Comparable<DiskItem> {
     private final String displayName;
     private final File path;
     private final Long usage;
+    private final Long count;
 
-    public DiskItem(String displayName, File path, Long usage) {
+    public DiskItem(String displayName, File path, Long usage, Long count) {
         this.displayName = displayName;
         this.path = path;
         this.usage = usage;
+        this.count = count;
+    }
+    
+    @Deprecated
+    public DiskItem(String displayName, File path, Long usage) {
+        this(displayName, path, usage, 0L);
     }
 
     public File getPath() {
@@ -49,6 +56,10 @@ public class DiskItem implements Comparable<DiskItem> {
 
     public Long getUsage() {
         return usage;
+    }
+
+    public Long getCount() {
+        return count;
     }
 
     public String getDisplayName() {

--- a/src/main/java/com/cloudbees/simplediskusage/JobDiskItem.java
+++ b/src/main/java/com/cloudbees/simplediskusage/JobDiskItem.java
@@ -33,10 +33,15 @@ public class JobDiskItem extends DiskItem {
     private final String fullName;
     private final String url;
 
-    public JobDiskItem(Job<?, ?> job, Long size) {
-        super(job.getFullDisplayName(), job.getRootDir(), size);
+    public JobDiskItem(Job<?, ?> job, Long size, Long count) {
+        super(job.getFullDisplayName(), job.getRootDir(), size, count);
         this.fullName = job.getFullName();
         this.url = job.getUrl();
+    }
+
+    @Deprecated
+    public JobDiskItem(Job<?, ?> job, Long size) {
+        this(job, size, 0L);
     }
 
     public String getFullName() {

--- a/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
+++ b/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
@@ -164,7 +164,7 @@ public class QuickDiskUsagePlugin extends Plugin {
 
         @Deprecated
         public void onCompleted(Path dir, long usage) {
-            onCompleted(dir, usage, 0);
+            onCompleted(dir, usage, 0L);
         }
         @Override
         public void onCompleted(Path dir, long usage, long count) {

--- a/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
+++ b/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
@@ -162,9 +162,13 @@ public class QuickDiskUsagePlugin extends Plugin {
             this.job = job;
         }
 
-        @Override
+        @Deprecated
         public void onCompleted(Path dir, long usage) {
-            JobDiskItem jobDiskItem = new JobDiskItem(job, usage / 1024);
+            onCompleted(dir, usage, 0);
+        }
+        @Override
+        public void onCompleted(Path dir, long usage, long count) {
+            JobDiskItem jobDiskItem = new JobDiskItem(job, usage / 1024, count);
             jobsUsages.remove(jobDiskItem);
             jobsUsages.add(jobDiskItem);
             progress.incrementAndGet();
@@ -178,9 +182,12 @@ public class QuickDiskUsagePlugin extends Plugin {
             this.displayName = displayName;
         }
 
-        @Override
         public void onCompleted(Path dir, long usage) {
-            DiskItem diskItem = new DiskItem(displayName, dir.toFile(), usage / 1024);
+            onCompleted(dir, usage, 0);
+        }
+        @Override
+        public void onCompleted(Path dir, long usage, long count) {
+            DiskItem diskItem = new DiskItem(displayName, dir.toFile(), usage / 1024, count);
             directoriesUsages.remove(diskItem);
             directoriesUsages.add(diskItem);
             progress.incrementAndGet();

--- a/src/main/java/com/cloudbees/simplediskusage/UsageComputation.java
+++ b/src/main/java/com/cloudbees/simplediskusage/UsageComputation.java
@@ -29,7 +29,6 @@ public class UsageComputation {
 
     public interface CompletionListener {
         void onCompleted(Path dir, long usage, long count);
-
     }
 
     private final Map<Path, CompletionListener> listenerMap;
@@ -41,7 +40,7 @@ public class UsageComputation {
     }
 
     public void addListener(Path path, CompletionListener listener) {
-         listenerMap.put(path.toAbsolutePath(), listener);
+        listenerMap.put(path.toAbsolutePath(), listener);
     }
 
     public int getItemsCount() {
@@ -62,7 +61,7 @@ public class UsageComputation {
                 long pathDiskUsage = jenkinsFSUsage();
                 CompletionListener listener = listenerMap.get(dir);
                 if (listener != null) {
-                    listener.onCompleted(dir, pathDiskUsage, 0);
+                    listener.onCompleted(dir, pathDiskUsage, 0L);
                 }
             }
             catch (Exception e){

--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/directories.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/directories.jelly
@@ -46,6 +46,7 @@
                     <tr>
                         <th initialSortDir="down">${%Item name}</th>
                         <th style="text-align: right">${%Disk usage} (kB)</th>
+                        <th style="text-align: right">${%Count}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -56,6 +57,12 @@
                                 <td style="text-align: right">
                                     <j:choose>
                                         <j:when test="${e.usage > 0}">${e.usage}</j:when>
+                                        <j:otherwise>N/A</j:otherwise>
+                                    </j:choose>
+                                </td>
+                                <td style="text-align: right">
+                                    <j:choose>
+                                        <j:when test="${e.count > 0}">${e.count}</j:when>
                                         <j:otherwise>N/A</j:otherwise>
                                     </j:choose>
                                 </td>

--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/index.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/index.jelly
@@ -46,6 +46,7 @@
                     <tr>
                         <th initialSortDir="down">${%Item name}</th>
                         <th style="text-align: right" >${%Disk usage} (kB)</th>
+                        <th style="text-align: right" >${%Amount}</th>
                         <th class="jenkins-table__cell--tight" data-sort-disable="true">${%Action}</th>
                     </tr>
                 </thead>
@@ -59,6 +60,12 @@
                                 <td style="text-align: right">
                                     <j:choose>
                                         <j:when test="${e.usage > 0}">${e.usage}</j:when>
+                                        <j:otherwise>N/A</j:otherwise>
+                                    </j:choose>
+                                </td>
+                                <td style="text-align: right">
+                                    <j:choose>
+                                        <j:when test="${e.count > 0}">${e.count}</j:when>
                                         <j:otherwise>N/A</j:otherwise>
                                     </j:choose>
                                 </td>

--- a/src/test/java/com/cloudbees/simplediskusage/UsageComputationTest.java
+++ b/src/test/java/com/cloudbees/simplediskusage/UsageComputationTest.java
@@ -18,7 +18,7 @@ public class UsageComputationTest {
         final UsageComputation uc = new UsageComputation(Arrays.asList(Paths.get(".")));
         uc.addListener(Paths.get("."), new UsageComputation.CompletionListener() {
             @Override
-            public void onCompleted(Path dir, long usage) {
+            public void onCompleted(Path dir, long usage, long count) {
                 notified.set(true);
                 testUsage.set(usage);
             }

--- a/src/test/java/com/cloudbees/simplediskusage/UsageComputationTest.java
+++ b/src/test/java/com/cloudbees/simplediskusage/UsageComputationTest.java
@@ -14,6 +14,7 @@ public class UsageComputationTest {
     public void compute() throws Exception {
         final AtomicBoolean notified = new AtomicBoolean(false);
         final AtomicLong testUsage = new AtomicLong(0);
+        final AtomicLong testCount = new AtomicLong(0);
 
         final UsageComputation uc = new UsageComputation(Arrays.asList(Paths.get(".")));
         uc.addListener(Paths.get("."), new UsageComputation.CompletionListener() {
@@ -21,11 +22,13 @@ public class UsageComputationTest {
             public void onCompleted(Path dir, long usage, long count) {
                 notified.set(true);
                 testUsage.set(usage);
+                testCount.set(count);
             }
         });
         uc.compute();
 
         Assert.assertTrue(notified.get());
         Assert.assertTrue(testUsage.get() >  0);
+        Assert.assertTrue(testCount.get() > 0);
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
When it comes to disk usage and the controller performance, not just the size of files but also the amount is relevant. This PR adds a new metric for the amount of files. As with the current metrics, it shows it for directories and jobs.

![image](https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/assets/41284403/15449ce7-fad3-4460-bb47-99d369a3c034)

Java Docs for methods have not been edited / added since there are none so far.

### Testing done

Unit tests and local instance

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
