### PR TITLE
[chore] Bump to a maven 3.9.x version of Maven

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 java temurin-11.0.20+101
-maven 3.8.5
+maven 3.9.5


### PR DESCRIPTION
To be aligned with the version used in jenkins.io.
cc @MarkEWaite 
