### PR TITLE
Modernize to Jenkins 2.401.3 with `jakarta.inject`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.74</version>
+    <version>4.75</version>
   </parent>
 
   <artifactId>cloudbees-disk-usage-simple</artifactId>
@@ -44,7 +44,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/cloudbees-disk-usage-simple-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.401.3</jenkins.version>
   </properties>
 
   <licenses>

--- a/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
+++ b/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
@@ -36,7 +36,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 import javax.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
Hi!

This PR aims to move this plugin to the [recommended](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) Jenkins baseline version.

2.401.2 was the [first version to include Guice 6.x](https://www.jenkins.io/changelog-stable/#v2.401.2), which supports `jakarta.inject`.

## Testing done
Ran `mvn clean verify`.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

Refs: sghill-rewrite/campaigns#1 sghill-rewrite/campaigns#2

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePlugin