### PR TITLE
style: Use monospace font to render Disk Usage and Amount

### DIFF
--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/index.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/index.jelly
@@ -59,13 +59,13 @@
                                 </td>
                                 <td style="text-align: right">
                                     <j:choose>
-                                        <j:when test="${e.usage > 0}">${e.usage}</j:when>
+                                        <j:when test="${e.usage > 0}"><code>${e.usage}</code></j:when>
                                         <j:otherwise>N/A</j:otherwise>
                                     </j:choose>
                                 </td>
                                 <td style="text-align: right">
                                     <j:choose>
-                                        <j:when test="${e.count > 0}">${e.count}</j:when>
+                                        <j:when test="${e.count > 0}"><code>${e.count}</code></j:when>
                                         <j:otherwise>N/A</j:otherwise>
                                     </j:choose>
                                 </td>


### PR DESCRIPTION
Without this, the width of `405215138` looks less than that of `399089984`.

<!-- Please describe your pull request here. -->

### Testing done

The UI uses monospace font for those two columns.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
