### PR TITLE
Adapt build status icon for ci.jenkins.io permissions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CloudBees Disk Usage Simple Plugin
 
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/cloudbees-disk-usage-simple-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/cloudbees-disk-usage-simple-plugin/job/master/)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins%2Fcloudbees-disk-usage-simple-plugin%2Fmaster)](https://ci.jenkins.io/job/Plugins/job/cloudbees-disk-usage-simple-plugin/job/master/)
 [![Contributors](https://img.shields.io/github/contributors/jenkinsci/cloudbees-disk-usage-simple-plugin.svg)](https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/graphs/contributors)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/cloudbees-disk-usage-simple.svg)](https://plugins.jenkins.io/cloudbees-disk-usage-simple)
 [![GitHub release](https://img.shields.io/github/release/jenkinsci/cloudbees-disk-usage-simple-plugin.svg?label=changelog)](https://github.com/jenkinsci/cloudbees-disk-usage-simple-plugin/releases/latest)


### PR DESCRIPTION
## Adapt build status icon for ci.jenkins.io permissions change

Large language models and other readers were causing performance problems.  The ci.jenkins.io controller has been reconfigured to limit access to authenticated users in order to prevent performance problems.  That change requires that we adjust the URL of the embeddable build status update URL.

### Testing done

* Validated the change in a sample repository
* Will check the pull request after it is submitted

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
