### PR TITLE
feat: expose disk usage data via /api/json and /api/xml

### DIFF
--- a/src/main/java/com/cloudbees/simplediskusage/DiskItem.java
+++ b/src/main/java/com/cloudbees/simplediskusage/DiskItem.java
@@ -23,6 +23,9 @@
  */
 package com.cloudbees.simplediskusage;
 
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
 import java.io.File;
 import java.util.Objects;
 
@@ -31,6 +34,7 @@ import java.util.Objects;
  *
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
+@ExportedBean
 public class DiskItem implements Comparable<DiskItem> {
 
     private final String displayName;
@@ -54,16 +58,24 @@ public class DiskItem implements Comparable<DiskItem> {
         return path;
     }
 
+    @Exported(name = "usageKB")
     public Long getUsage() {
         return usage;
     }
 
+    @Exported
     public Long getCount() {
         return count;
     }
 
+    @Exported
     public String getDisplayName() {
         return displayName;
+    }
+
+    @Exported
+    public String getPathString() {
+        return path.getAbsolutePath();
     }
 
     /**

--- a/src/main/java/com/cloudbees/simplediskusage/JobDiskItem.java
+++ b/src/main/java/com/cloudbees/simplediskusage/JobDiskItem.java
@@ -24,6 +24,7 @@
 package com.cloudbees.simplediskusage;
 
 import hudson.model.Job;
+import org.kohsuke.stapler.export.Exported;
 
 /**
  * A job directory path on the disk with its usage information
@@ -44,10 +45,12 @@ public class JobDiskItem extends DiskItem {
         this(job, size, 0L);
     }
 
+    @Exported
     public String getFullName() {
         return fullName;
     }
 
+    @Exported
     public String getUrl() {
         return url;
     }

--- a/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
+++ b/src/main/java/com/cloudbees/simplediskusage/QuickDiskUsagePlugin.java
@@ -25,7 +25,9 @@ package com.cloudbees.simplediskusage;
 
 import hudson.*;
 import hudson.init.InitMilestone;
+import hudson.model.Api;
 import hudson.model.Job;
+import hudson.model.ModelObject;
 import hudson.model.TopLevelItem;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
@@ -34,6 +36,8 @@ import jenkins.model.Jenkins;
 import jenkins.util.Timer;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import jakarta.inject.Singleton;
@@ -52,9 +56,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+@ExportedBean
 @Extension
 @Singleton
-public class QuickDiskUsagePlugin extends Plugin {
+public class QuickDiskUsagePlugin extends Plugin implements ModelObject {
 
     public static final int QUIET_PERIOD = 15 * 60 * 1000;
 
@@ -88,6 +93,15 @@ public class QuickDiskUsagePlugin extends Plugin {
         }
     }
 
+    @Override
+    public String getDisplayName() {
+        return "Disk Usage";
+    }
+
+    public Api getApi() {
+        return new Api(this);
+    }
+
     public void refreshData() {
         if (!isRunning()) {
             singleExecutorService.execute(computeDiskUsage);
@@ -98,6 +112,7 @@ public class QuickDiskUsagePlugin extends Plugin {
          singleExecutorService.execute(computeDiskUsageOnStartup);
     }
 
+    @Exported(inline = true)
     public CopyOnWriteArrayList<DiskItem> getDirectoriesUsages() throws IOException {
         if (System.currentTimeMillis() - lastRunEnd >= QUIET_PERIOD) {
             refreshData();
@@ -105,6 +120,7 @@ public class QuickDiskUsagePlugin extends Plugin {
         return directoriesUsages;
     }
 
+    @Exported(inline = true)
     public CopyOnWriteArrayList<JobDiskItem> getJobsUsages() throws IOException {
         if (System.currentTimeMillis() - lastRunEnd >= QUIET_PERIOD) {
             refreshData();
@@ -112,10 +128,12 @@ public class QuickDiskUsagePlugin extends Plugin {
         return jobsUsages;
     }
 
+    @Exported
     public long getLastRunStart() {
         return lastRunStart;
     }
 
+    @Exported
     public long getLastRunEnd() {
         return lastRunEnd;
     }

--- a/src/test/java/com/cloudbees/simplediskusage/DiskUsageApiTest.java
+++ b/src/test/java/com/cloudbees/simplediskusage/DiskUsageApiTest.java
@@ -1,0 +1,168 @@
+package com.cloudbees.simplediskusage;
+
+import hudson.model.FreeStyleProject;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@WithJenkins
+class DiskUsageApiTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
+
+    @Test
+    void apiEndpointIsReachable() throws Exception {
+        var response = j.createWebClient().goTo("manage/disk-usage-simple/api/json", "application/json");
+        assertEquals(200, response.getWebResponse().getStatusCode());
+    }
+
+    @Test
+    void apiResponseContainsTopLevelFields() throws Exception {
+        var response = j.createWebClient().goTo("manage/disk-usage-simple/api/json", "application/json");
+        var json = JSONObject.fromObject(response.getWebResponse().getContentAsString());
+
+        assertTrue(json.has("directoriesUsages"), "missing directoriesUsages");
+        assertTrue(json.has("jobsUsages"), "missing jobsUsages");
+        assertTrue(json.has("lastRunStart"), "missing lastRunStart");
+        assertTrue(json.has("lastRunEnd"), "missing lastRunEnd");
+    }
+
+    @Test
+    void directoryItemsExposeExpectedFields() throws Exception {
+        var plugin = j.jenkins.getPlugin(QuickDiskUsagePlugin.class);
+        assertNotNull(plugin);
+
+        // Inject a known item directly so the test doesn't depend on the slow async scan
+        inject(plugin, "directoriesUsages", List.of(
+                new DiskItem("TEST_DIR", new File("/tmp"), 2048L, 42L)));
+        markScanComplete(plugin);
+
+        var response = j.createWebClient().goTo("manage/disk-usage-simple/api/json", "application/json");
+        var json = JSONObject.fromObject(response.getWebResponse().getContentAsString());
+        var dirs = json.getJSONArray("directoriesUsages");
+
+        assertFalse(dirs.isEmpty(), "directoriesUsages should not be empty");
+
+        var item = dirs.getJSONObject(0);
+        assertTrue(item.has("displayName"), "missing displayName");
+        assertTrue(item.has("usageKB"), "missing usageKB");
+        assertTrue(item.has("count"), "missing count");
+        assertTrue(item.has("pathString"), "missing pathString");
+        assertFalse(item.has("usage"), "should not expose raw 'usage' field — use 'usageKB'");
+
+        assertEquals("TEST_DIR", item.getString("displayName"));
+        assertEquals(2048L, item.getLong("usageKB"));
+        assertEquals(42L, item.getLong("count"));
+    }
+
+    @Test
+    void jobItemsExposeExpectedFields() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("api-test-job");
+        var plugin = j.jenkins.getPlugin(QuickDiskUsagePlugin.class);
+        assertNotNull(plugin);
+
+        inject(plugin, "jobsUsages", List.of(
+                new JobDiskItem(project, 512L, 7L)));
+        markScanComplete(plugin);
+
+        var response = j.createWebClient().goTo("manage/disk-usage-simple/api/json", "application/json");
+        var json = JSONObject.fromObject(response.getWebResponse().getContentAsString());
+        var jobs = json.getJSONArray("jobsUsages");
+
+        var jobEntry = findByFullName(jobs, "api-test-job");
+        assertNotNull(jobEntry, "api-test-job not found in jobsUsages");
+
+        assertTrue(jobEntry.has("displayName"), "missing displayName");
+        assertTrue(jobEntry.has("usageKB"), "missing usageKB");
+        assertTrue(jobEntry.has("count"), "missing count");
+        assertTrue(jobEntry.has("pathString"), "missing pathString");
+        assertTrue(jobEntry.has("fullName"), "missing fullName");
+        assertTrue(jobEntry.has("url"), "missing url");
+        assertFalse(jobEntry.has("usage"), "should not expose raw 'usage' field — use 'usageKB'");
+
+        assertEquals("api-test-job", jobEntry.getString("fullName"));
+        assertEquals(512L, jobEntry.getLong("usageKB"));
+    }
+
+    @Test
+    void usageKBReflectsActualDiskSize() throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject("disk-size-job");
+
+        // Write ~1MB of data into the job's root dir (simulating archived artifacts)
+        var artifactDir = new File(project.getRootDir(), "builds/1/archive");
+        artifactDir.mkdirs();
+        Files.write(new File(artifactDir, "data.bin").toPath(), new byte[1024 * 1024]);
+
+        // Run UsageComputation synchronously on just this one job directory,
+        // bypassing the slow full-Jenkins scan that also walks java.io.tmpdir
+        var result = new AtomicLong(-1);
+        var uc = new UsageComputation(List.of(project.getRootDir().toPath()));
+        uc.addListener(project.getRootDir().toPath(), (dir, usage, count) -> result.set(usage));
+        uc.compute();
+
+        assertTrue(result.get() >= 0, "UsageComputation did not call the listener");
+        // usage from UsageComputation is in bytes; plugin divides by 1024 before storing
+        long usageKB = result.get() / 1024;
+        // The 1MB file should produce ~1024 KB (within 10% tolerance for filesystem metadata)
+        assertTrue(usageKB >= 900, "expected usageKB >= 900, got " + usageKB);
+        assertTrue(usageKB <= 2048, "expected usageKB <= 2048, got " + usageKB);
+    }
+
+    @Test
+    void xmlEndpointIsReachable() throws Exception {
+        var response = j.createWebClient().goTo("manage/disk-usage-simple/api/xml", "application/xml");
+        assertEquals(200, response.getWebResponse().getStatusCode());
+        var body = response.getWebResponse().getContentAsString();
+        // Stapler derives the root element name from the class name; attributes may follow
+        assertTrue(body.contains("<quickDiskUsagePlugin"), "XML response missing root element");
+    }
+
+    // --- helpers ---
+
+    @SuppressWarnings("unchecked")
+    private <T> void inject(QuickDiskUsagePlugin plugin, String fieldName, List<T> items)
+            throws ReflectiveOperationException {
+        Field f = QuickDiskUsagePlugin.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        var list = (CopyOnWriteArrayList<T>) f.get(plugin);
+        list.clear();
+        list.addAll(items);
+    }
+
+    private void markScanComplete(QuickDiskUsagePlugin plugin) throws ReflectiveOperationException {
+        long now = System.currentTimeMillis();
+        Field start = QuickDiskUsagePlugin.class.getDeclaredField("lastRunStart");
+        Field end = QuickDiskUsagePlugin.class.getDeclaredField("lastRunEnd");
+        start.setAccessible(true);
+        end.setAccessible(true);
+        start.set(plugin, now - 1000);
+        end.set(plugin, now);
+    }
+
+    private JSONObject findByFullName(JSONArray jobs, String fullName) {
+        for (int i = 0; i < jobs.size(); i++) {
+            var entry = jobs.getJSONObject(i);
+            if (fullName.equals(entry.optString("fullName"))) {
+                return entry;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
This allows Jenkins operators to script actions they take when they're running low on disk.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
