### PR TITLE
Display disk usage human readable

### DIFF
--- a/src/main/java/com/cloudbees/simplediskusage/DiskItem.java
+++ b/src/main/java/com/cloudbees/simplediskusage/DiskItem.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.simplediskusage;
 
-import hudson.Functions;
 import java.text.DecimalFormat;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;

--- a/src/main/java/com/cloudbees/simplediskusage/DiskItem.java
+++ b/src/main/java/com/cloudbees/simplediskusage/DiskItem.java
@@ -23,6 +23,8 @@
  */
 package com.cloudbees.simplediskusage;
 
+import hudson.Functions;
+import java.text.DecimalFormat;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -85,6 +87,26 @@ public class DiskItem implements Comparable<DiskItem> {
     public String getUsageInMB() {
         float mbValue = usage / 1024.0f;
         return String.format("%.1f", mbValue);
+    }
+
+    public String getUsageFormatted() {
+        String measure = "KiB";
+        if (usage < 1024) {
+            return usage + " " + measure;
+        }
+        double number = usage;
+        number = number / 1024;
+        measure = "MiB";
+        if (number >= 1024) {
+            number = number / 1024;
+            measure = "GiB";
+            if (number >= 1024) {
+                number = number / 1024;
+                measure = "TiB";
+            }
+        }
+        DecimalFormat format = new DecimalFormat("#0.0");
+        return format.format(number) + " " + measure;
     }
 
     @Override

--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/directories.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/directories.jelly
@@ -45,7 +45,7 @@
                 <thead>
                     <tr>
                         <th initialSortDir="down">${%item_name}</th>
-                        <th style="text-align: right">${%disk_usage} (MB)</th>
+                        <th style="text-align: right">${%disk_usage}</th>
                         <th style="text-align: right">${%files}</th>
                     </tr>
                 </thead>
@@ -56,7 +56,7 @@
                                 <td>${e.displayName}</td>
                                 <td style="text-align: right" data="${e.usage}">
                                     <j:choose>
-                                        <j:when test="${e.usage > 0}">${e.usageInMB}</j:when>
+                                        <j:when test="${e.usage > 0}">${e.usageFormatted}</j:when>
                                         <j:otherwise>N/A</j:otherwise>
                                     </j:choose>
                                 </td>

--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/directories.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/directories.jelly
@@ -54,13 +54,13 @@
                         <j:if test="${e.usage != 0}">
                             <tr>
                                 <td>${e.displayName}</td>
-                                <td style="text-align: right">
+                                <td style="text-align: right" data="${e.usage}">
                                     <j:choose>
                                         <j:when test="${e.usage > 0}">${e.usageInMB}</j:when>
                                         <j:otherwise>N/A</j:otherwise>
                                     </j:choose>
                                 </td>
-                                <td style="text-align: right">
+                                <td style="text-align: right" data="${e.count}">
                                     <j:choose>
                                         <j:when test="${e.count > 0}">${e.count}</j:when>
                                         <j:otherwise>N/A</j:otherwise>

--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/index.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/index.jelly
@@ -45,7 +45,7 @@
                 <thead>
                     <tr>
                         <th initialSortDir="down">${%item_name}</th>
-                        <th style="text-align: right" >${%disk_usage} (MB)</th>
+                        <th style="text-align: right" >${%disk_usage}</th>
                         <th style="text-align: right" >${%files}</th>
                         <th class="jenkins-table__cell--tight" data-sort-disable="true">${%Action}</th>
                     </tr>
@@ -59,7 +59,7 @@
                                 </td>
                                 <td style="text-align: right" data="${e.usage}">
                                     <j:choose>
-                                        <j:when test="${e.usage > 0}"><code>${e.usageInMB}</code></j:when>
+                                        <j:when test="${e.usage > 0}"><code>${e.usageFormatted}</code></j:when>
                                         <j:otherwise>N/A</j:otherwise>
                                     </j:choose>
                                 </td>

--- a/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/index.jelly
+++ b/src/main/resources/com/cloudbees/simplediskusage/QuickDiskUsagePlugin/index.jelly
@@ -57,13 +57,13 @@
                                 <td>
                                     <a href="${rootURL}/${e.url}" class="jenkins-table__link model-link inside">${e.displayName}</a>
                                 </td>
-                                <td style="text-align: right">
+                                <td style="text-align: right" data="${e.usage}">
                                     <j:choose>
                                         <j:when test="${e.usage > 0}"><code>${e.usageInMB}</code></j:when>
                                         <j:otherwise>N/A</j:otherwise>
                                     </j:choose>
                                 </td>
-                                <td style="text-align: right">
+                                <td style="text-align: right" data="${e.count}">
                                     <j:choose>
                                         <j:when test="${e.count > 0}"><code>${e.count}</code></j:when>
                                         <j:otherwise>N/A</j:otherwise>


### PR DESCRIPTION
Instead of always using MiB, use a human readable format with a fitting size, i.e. KiB, MiB, GiB or TiB
<!-- Please describe your pull request here. -->

includes #190 which is mandatory to get the sorting right.

Before:


### Testing done
Interactive testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
